### PR TITLE
Add assertThrows

### DIFF
--- a/docs/Test/Assert.md
+++ b/docs/Test/Assert.md
@@ -26,4 +26,16 @@ assert' :: forall e. String -> Boolean -> Eff (assert :: ASSERT | e) Unit
 Throws a runtime exception with the specified message when the boolean
 value is false.
 
+#### `assertThrows`
+
+``` purescript
+assertThrows :: forall e a. (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
+```
+
+#### `assertThrows'`
+
+``` purescript
+assertThrows' :: forall e a. String -> (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
+```
+
 

--- a/docs/Test/Assert.md
+++ b/docs/Test/Assert.md
@@ -35,6 +35,11 @@ assertThrows :: forall e a. (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
 Throws a runtime exception with message "Assertion failed: An error should
 have been thrown", unless the argument throws an exception when evaluated.
 
+This function is specifically for testing unsafe pure code; for example,
+to make sure that an exception is thrown if a precondition is not
+satisfied. Functions which use `Eff (err :: EXCEPTION | eff) a` can be
+tested with `catchException` instead.
+
 #### `assertThrows'`
 
 ``` purescript
@@ -43,5 +48,10 @@ assertThrows' :: forall e a. String -> (Unit -> a) -> Eff (assert :: ASSERT | e)
 
 Throws a runtime exception with the specified message, unless the argument
 throws an exception when evaluated.
+
+This function is specifically for testing unsafe pure code; for example,
+to make sure that an exception is thrown if a precondition is not
+satisfied. Functions which use `Eff (err :: EXCEPTION | eff) a` can be
+tested with `catchException` instead.
 
 

--- a/docs/Test/Assert.md
+++ b/docs/Test/Assert.md
@@ -32,10 +32,16 @@ value is false.
 assertThrows :: forall e a. (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
 ```
 
+Throws a runtime exception with message "Assertion failed: An error should
+have been thrown", unless the argument throws an exception when evaluated.
+
 #### `assertThrows'`
 
 ``` purescript
 assertThrows' :: forall e a. String -> (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
 ```
+
+Throws a runtime exception with the specified message, unless the argument
+throws an exception when evaluated.
 
 

--- a/src/Test/Assert.js
+++ b/src/Test/Assert.js
@@ -11,3 +11,17 @@ exports["assert'"] = function (message) {
     };
   };
 };
+
+exports.checkThrows = function (fn) {
+  return function () {
+    try {
+      fn();
+      return false;
+    } catch (e) {
+      if (e instanceof Error) return true;
+      var err = new Error("Threw something other than an Error");
+      err.something = e;
+      throw err;
+    }
+  };
+};

--- a/src/Test/Assert.purs
+++ b/src/Test/Assert.purs
@@ -21,9 +21,13 @@ assert = assert' "Assertion failed"
 -- | value is false.
 foreign import assert' :: forall e. String -> Boolean -> Eff (assert :: ASSERT | e) Unit
 
+-- | Throws a runtime exception with message "Assertion failed: An error should
+-- | have been thrown", unless the argument throws an exception when evaluated.
 assertThrows :: forall e a. (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
 assertThrows = assertThrows' "Assertion failed: An error should have been thrown"
 
+-- | Throws a runtime exception with the specified message, unless the argument
+-- | throws an exception when evaluated.
 assertThrows' :: forall e a. String -> (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
 assertThrows' msg fn =
   checkThrows fn >>= assert' msg

--- a/src/Test/Assert.purs
+++ b/src/Test/Assert.purs
@@ -1,4 +1,10 @@
-module Test.Assert where
+module Test.Assert
+  ( assert'
+  , assert
+  , assertThrows
+  , assertThrows'
+  , ASSERT()
+  ) where
 
 import Control.Monad.Eff (Eff())
 import Prelude
@@ -14,3 +20,13 @@ assert = assert' "Assertion failed"
 -- | Throws a runtime exception with the specified message when the boolean
 -- | value is false.
 foreign import assert' :: forall e. String -> Boolean -> Eff (assert :: ASSERT | e) Unit
+
+assertThrows :: forall e a. (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
+assertThrows = assertThrows' "Assertion failed: An error should have been thrown"
+
+assertThrows' :: forall e a. String -> (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
+assertThrows' msg fn =
+  checkThrows fn >>= assert' msg
+
+
+foreign import checkThrows :: forall e a. (Unit -> a) -> Eff (assert :: ASSERT | e) Boolean

--- a/src/Test/Assert.purs
+++ b/src/Test/Assert.purs
@@ -23,11 +23,21 @@ foreign import assert' :: forall e. String -> Boolean -> Eff (assert :: ASSERT |
 
 -- | Throws a runtime exception with message "Assertion failed: An error should
 -- | have been thrown", unless the argument throws an exception when evaluated.
+-- |
+-- | This function is specifically for testing unsafe pure code; for example,
+-- | to make sure that an exception is thrown if a precondition is not
+-- | satisfied. Functions which use `Eff (err :: EXCEPTION | eff) a` can be
+-- | tested with `catchException` instead.
 assertThrows :: forall e a. (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
 assertThrows = assertThrows' "Assertion failed: An error should have been thrown"
 
 -- | Throws a runtime exception with the specified message, unless the argument
 -- | throws an exception when evaluated.
+-- |
+-- | This function is specifically for testing unsafe pure code; for example,
+-- | to make sure that an exception is thrown if a precondition is not
+-- | satisfied. Functions which use `Eff (err :: EXCEPTION | eff) a` can be
+-- | tested with `catchException` instead.
 assertThrows' :: forall e a. String -> (Unit -> a) -> Eff (assert :: ASSERT | e) Unit
 assertThrows' msg fn =
   checkThrows fn >>= assert' msg


### PR DESCRIPTION
I'm currently trying to improve the compiler test suite, and so this is to replace `assertPartial` in the test prelude. This will probably be useful more generally too, though.
