### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Test/Assert.js
+++ b/src/Test/Assert.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports["assert'"] = function (message) {
+exports.assertImpl = function (message) {
   return function (success) {
     return function () {
       if (!success) throw new Error(message);

--- a/src/Test/Assert.purs
+++ b/src/Test/Assert.purs
@@ -23,7 +23,10 @@ assert = assert' "Assertion failed"
 
 -- | Throws a runtime exception with the specified message when the boolean
 -- | value is false.
-foreign import assert'
+assert' :: String -> Boolean -> Effect Unit
+assert' = assertImpl
+
+foreign import assertImpl
   :: String
   -> Boolean
   -> Effect Unit


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.