### PR TITLE
Update to v0.14.0-rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js: stable
 env:
   - PATH=$HOME/purescript:$PATH
 install:
-  - TAG=$(basename $(curl --location --silent --output /dev/null -w %{url_effective} https://github.com/purescript/purescript/releases/latest))
+  # - TAG=$(basename $(curl --location --silent --output /dev/null -w %{url_effective} https://github.com/purescript/purescript/releases/latest))
+  - TAG=v0.14.0-rc2
   - curl --location --output $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
   - tar -xvf $HOME/purescript.tar.gz -C $HOME/
   - chmod a+x $HOME/purescript

--- a/bower.json
+++ b/bower.json
@@ -16,8 +16,8 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-effect": "^2.0.0",
-    "purescript-console": "^4.0.0",
-    "purescript-prelude": "^4.0.0"
+    "purescript-effect": "master",
+    "purescript-console": "master",
+    "purescript-prelude": "master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "pulp": "^15.0.0",
-    "purescript-psa": "^0.6.0",
+    "purescript-psa": "^0.8.0",
     "rimraf": "^2.6.2"
   }
 }

--- a/src/Test/Assert.js
+++ b/src/Test/Assert.js
@@ -4,7 +4,6 @@ exports["assert'"] = function (message) {
   return function (success) {
     return function () {
       if (!success) throw new Error(message);
-      return {};
     };
   };
 };

--- a/src/Test/Assert.js
+++ b/src/Test/Assert.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports["assert'"] = function (message) {
+exports.assertImpl = function (message) {
   return function (success) {
     return function () {
       if (!success) throw new Error(message);

--- a/src/Test/Assert.purs
+++ b/src/Test/Assert.purs
@@ -23,7 +23,10 @@ assert = assert' "Assertion failed"
 
 -- | Throws a runtime exception with the specified message when the boolean
 -- | value is false.
-foreign import assert'
+assert' :: String -> Boolean -> Effect Unit
+assert' = assertImpl
+
+foreign import assertImpl
   :: String
   -> Boolean
   -> Effect Unit


### PR DESCRIPTION
- Remove `return {}` from FFI function
- Remove primes from foreign modules exports
